### PR TITLE
integrate changes from securimage 4.0.2 for compatibility with PHP8.2

### DIFF
--- a/securimage/securimage_preview.php
+++ b/securimage/securimage_preview.php
@@ -30,7 +30,7 @@ $temp_conf = array(
 // randomize colors
 function randomColor()
 {
-  $c = null;
+  $c = '';
   while(strlen($c)<6)
   {
     $c .= sprintf("%02X", mt_rand(0, 255));

--- a/securimage/securimage_show.php
+++ b/securimage/securimage_show.php
@@ -55,7 +55,7 @@ require_once dirname(__FILE__) . '/securimage.php';
 // randomize colors 
 function randomColor()
 {
-  $c = null;
+  $c = '';
   while(strlen($c)<6)
   {
     $c .= sprintf("%02X", mt_rand(0, 255));


### PR DESCRIPTION
I was able to run the Crypto Captcha Plugin with Piwigo 15 on PHP 8.1, but it failed when I switch to PHP 8.2. I integrated some changed from the [securimage.php](https://github.com/dapphp/securimage/blob/nextgen/securimage.php) file in the source repo. 

Even if this Repo is currently not maintained, it may be helpful for other who struggle with this. Since I am using the **Bootstrap Darkroom** theme, this is the only Captcha plugin which is working. 

Kind regards

Jens
